### PR TITLE
feat: loadParameterStoreValue 실행시 우선순위를 통해 env 변수 지정

### DIFF
--- a/src/env/ssm-config.service.ts
+++ b/src/env/ssm-config.service.ts
@@ -13,7 +13,7 @@ export default class SSMConfigService {
   private readonly ssmClient: SSMClient;
   private readonly ssmClientConfig: SSMClientConfig;
   private readonly logger = new Logger(SSMConfigService.name);
-  prefix = `/mgmg/${process.env.NODE_ENV}/`;
+  private readonly prefix:string = `/mgmg/${process.env.NODE_ENV}/`;
 
   constructor(private readonly configService: ConfigService) {
     this.ssmClientConfig = {
@@ -73,22 +73,40 @@ export default class SSMConfigService {
 }
 
 export const loadParameterStoreValue = async () => {
+  const regex = /mgmg\/.+?\//;
+
   return new SSMClient({
     region: process.env.AWS_REGION,
     credentials: {
       accessKeyId: process.env.AWS_IAM_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_IAM_SECRET_ACCESS_KEY,
-    },
+      secretAccessKey: process.env.AWS_IAM_SECRET_ACCESS_KEY
+    }
   })
     .send(
       new GetParametersByPathCommand({
-        Path: `/mgmg/${process.env.NODE_ENV}/`,
-      }),
+        Path: '/mgmg/',
+        Recursive: true
+      })
     )
     .then((v) => {
-      for (const parameter of v.Parameters) {
-        const split: string[] = parameter.Name.split('/');
-        process.env[split[split.length - 1]] = parameter.Value;
+
+      const parameters = v.Parameters.sort((a, b) => {
+        // 환경에 따라 다른 가중치를 반환하는 함수
+        const getWeight = (env) => {
+          if (env === 'prod') return env === process.env.NODE_ENV ? 1 : 3;
+          if (env === 'dev') return env === process.env.NODE_ENV ? 1 : 2;
+          return 0;
+        };
+
+        const envA = a.Name.match(regex)[1];
+        const envB = b.Name.match(regex)[1];
+        return getWeight(envB) - getWeight(envA);
+      });
+
+      for (const parameter of parameters) {
+        let name = parameter.Name;
+        const key = name.replace(regex, '');
+        key.indexOf('/') === 0 ? process.env[key.substring(1)] = parameter.Value : process.env[key] = parameter.Value;
       }
     });
 };


### PR DESCRIPTION
### **AWS 파라미터 스토어에서 변수를 가져올때 우선순위에 따라서 환경변수에 등록하도록 수정하였습니다.**

1.  특정 환경(NODE_ENV)에만 있는 경우 
- 등록이 됩니다. 예를들어 parameter store에서 mgmg/dev/datasource/db만 있고 local이 없다고 가정한다면 dev의 datasource/db가 등록됩니다.

2. 환경마다 있는 경우
- 우선순위에 따라서 다르게 등록됩니다.

우선순위
1) 현재 NODE_ENV에 속하는 파라미터
2) prod
3) dev
4) local