### PR TITLE
refactor: AuthModule Global Module화

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { AuthService } from './application/auth.service';
 import { AuthController } from './presentation/auth.controller';
 import { CustomerModule } from 'src/customer/customer.module';
@@ -9,6 +9,7 @@ import { JwtRefreshStrategy } from './application/jwt-refresh.strategy';
 import { PassportModule } from '@nestjs/passport';
 import { CacheModule } from '../common/cache/cache.module';
 
+@Global()
 @Module({
   imports: [
     JwtModule.registerAsync({
@@ -23,6 +24,6 @@ import { CacheModule } from '../common/cache/cache.module';
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtAccessStrategy, JwtRefreshStrategy],
-  exports: [AuthService, JwtAccessStrategy, JwtRefreshStrategy],
+  exports: [AuthService, JwtAccessStrategy, JwtRefreshStrategy, PassportModule],
 })
 export class AuthModule {}

--- a/src/auth/decorator/customer.decorator.ts
+++ b/src/auth/decorator/customer.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Customer } from '../../customer/entities/customer.entity';
+
+export const CurrentCustomer = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const req: { user?: Customer } = context.switchToHttp().getRequest();
+    return req.user;
+  },
+);

--- a/src/customer/customer.module.ts
+++ b/src/customer/customer.module.ts
@@ -3,13 +3,9 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CustomerService } from './application/customer.service';
 import { Customer } from './entities/customer.entity';
 import { CustomerController } from './presentation/customer.controller';
-import { PassportModule } from '@nestjs/passport';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Customer]),
-    PassportModule.register({ defaultStrategy: 'access' }),
-  ],
+  imports: [TypeOrmModule.forFeature([Customer])],
   controllers: [CustomerController],
   providers: [CustomerService],
   exports: [CustomerService],

--- a/src/customer/presentation/customer.controller.ts
+++ b/src/customer/presentation/customer.controller.ts
@@ -1,7 +1,9 @@
 import { CustomerService } from '../application/customer.service';
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { CustomerDto } from './customer.dto';
+import { Customer } from '../entities/customer.entity';
+import { CurrentCustomer } from '../../auth/decorator/customer.decorator';
 
 @Controller('/api/v1/customer')
 export class CustomerController {
@@ -9,9 +11,11 @@ export class CustomerController {
 
   @Get('my')
   @UseGuards(AuthGuard())
-  async getMyCustomer(@Req() req: any): Promise<CustomerDto> {
+  async getMyCustomer(
+    @CurrentCustomer() customer: Customer,
+  ): Promise<CustomerDto> {
     return {
-      ...req.user,
+      ...customer,
     };
   }
 }


### PR DESCRIPTION
## 🎫 없음

- 🛠️ 코드 리팩토링

## 변경 사항에 대한 설명

1. 여러 Module에서 중복되어 사용될 AuthGuard를 전역적으로 사용할 수 있도록 AuthModule을 GlobalModule로 등록합니다.
2. Customer 인증 객체 decorator로 객체 주입


## 테스트 방법
1. 타 Module의 Controller에서 AuthGuard 사용시 오른쪽 사진처럼 
> In order to use "defaultStrategy", please, ensure to import PassportModule in each place where AuthGuard() is being used. Otherwise, passport won't work correctly

해당 로그 발생시 AuthGuard가 정상적으로 동작하지 않음

|성공 예시|실패 예시|
|------|---|
|<img alt="스크린샷 2024-04-15 오전 8 43 15" src="https://github.com/PBTP/mongle-server/assets/73595178/4afdcfaf-1bf4-40b3-9606-a13ffefb4244">|<img alt="스크린샷 2024-04-15 오전 8 43 37" src="https://github.com/PBTP/mongle-server/assets/73595178/1ca49430-b201-43b3-ab3d-33153f678c55">|

2. Controller에서 @CurrentCustomer를 통해 파라미터에 객체 주입 후 log 를 통해 확인 (실패시 undefined 혹은 error 발생)
