### PR TITLE
Rename: parameter store prefix 변경

### DIFF
--- a/src/env/ssm-config.service.ts
+++ b/src/env/ssm-config.service.ts
@@ -14,7 +14,7 @@ export default class SSMConfigService {
   private readonly ssmClient: SSMClient;
   private readonly ssmClientConfig: SSMClientConfig;
   private readonly logger = new Logger(SSMConfigService.name);
-  private readonly prefix: string = `/mgmg/${process.env.NODE_ENV}/`;
+  private readonly prefix: string = `/mgmg/server/${process.env.NODE_ENV}/`;
 
   constructor(private readonly configService: ConfigService) {
     this.ssmClientConfig = {
@@ -74,7 +74,7 @@ export default class SSMConfigService {
 }
 
 export const loadParameterStoreValue = async () => {
-  const regex = /\/mgmg\/[^/]*\//;
+  const regex = /\/mgmg\/server\/[^/]*\//;
   const nodeEnv = process.env.NODE_ENV;
   let nextToken: string | undefined;
   const parameters: Parameter[] = [];
@@ -90,7 +90,7 @@ export const loadParameterStoreValue = async () => {
   do {
     const response = await ssmClient.send(
       new GetParametersByPathCommand({
-        Path: '/mgmg/',
+        Path: '/mgmg/server/',
         Recursive: true,
         WithDecryption: true,
         MaxResults: 10,
@@ -104,9 +104,9 @@ export const loadParameterStoreValue = async () => {
 
   parameters.sort((a: Parameter, b: Parameter) => {
     const getWeight = (env: string) => {
-      if (env.startsWith(`/mgmg/${nodeEnv}/`)) return 0;
-      if (env.startsWith('/mgmg/prod/')) return 2;
-      if (env.startsWith('/mgmg/dev/')) return 1;
+      if (env.startsWith(`/mgmg/server/${nodeEnv}/`)) return 0;
+      if (env.startsWith('/mgmg/server/prod/')) return 2;
+      if (env.startsWith('/mgmg/server/dev/')) return 1;
 
       return 3;
     };


### PR DESCRIPTION
## X
- 🛠️ 코드 리팩토링

## 변경 사항에 대한 설명

프론트 개발자 분들이 ParameterStore를 도입한다고 하셔서 prefix를 변경하였습니다.
때문에 코드도 같이 수정하였습니다.

## 테스트 방법

process.env 변수를 출력하여 확인.