### PR TITLE
refactor: Auth 데코레이터로 UserGuards, ApiBearAuth, ApiUnauthorizedResponse 통합처리

### DIFF
--- a/src/auth/decorator/auth.decorator.ts
+++ b/src/auth/decorator/auth.decorator.ts
@@ -1,0 +1,27 @@
+import {
+  applyDecorators,
+  createParamDecorator,
+  ExecutionContext,
+  UseGuards,
+} from '@nestjs/common';
+import { Customer } from '../../schemas/customers.entity';
+import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+
+export const CurrentCustomer = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const req: { user?: Customer } = context.switchToHttp().getRequest();
+    return req.user;
+  },
+);
+
+export function Auth(authGuardType: string = 'access') {
+  return applyDecorators(
+    UseGuards(AuthGuard(authGuardType)),
+    ApiBearerAuth(),
+    ApiUnauthorizedResponse({
+      description:
+        'Unauthorized / Access Token이 만료되었거나 잘못되었습니다. 토큰을 갱신하세요',
+    }),
+  );
+}

--- a/src/auth/decorator/customer.decorator.ts
+++ b/src/auth/decorator/customer.decorator.ts
@@ -1,9 +1,0 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { Customer } from '../../schemas/customers.entity';
-
-export const CurrentCustomer = createParamDecorator(
-  (data: unknown, context: ExecutionContext) => {
-    const req: { user?: Customer } = context.switchToHttp().getRequest();
-    return req.user;
-  },
-);

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -1,15 +1,14 @@
-import { Controller, Post, Body, UseGuards, Req } from '@nestjs/common';
+import { Controller, Post, Body, Req } from '@nestjs/common';
 import { AuthService } from '../application/auth.service';
 import { AuthDto } from './auth.dto';
-import { AuthGuard } from '@nestjs/passport';
 import {
-  ApiBearerAuth,
   ApiCreatedResponse,
   ApiOperation,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
 import { CustomerDto } from '../../customer/presentation/customer.dto';
+import { Auth } from '../decorator/auth.decorator';
 
 @ApiTags('인증 관련 API')
 @Controller('/v1/auth')
@@ -41,9 +40,8 @@ export class AuthController {
     description:
       'Unauthorized / 요청한 Refresh Token에 해당하는 고객이 없습니다.',
   })
-  @ApiBearerAuth()
+  @Auth('refresh')
   @Post('/refresh')
-  @UseGuards(AuthGuard('refresh'))
   async refresh(@Req() req: Request): Promise<AuthDto> {
     return await this.authService.tokenRefresh(req);
   }

--- a/src/common/image/presentation/image.controller.ts
+++ b/src/common/image/presentation/image.controller.ts
@@ -1,14 +1,6 @@
-import {
-  Body,
-  Controller,
-  HttpCode,
-  Post,
-  Query,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, Query } from '@nestjs/common';
 import { ImageService } from '../application/image.service';
-import { CurrentCustomer } from '../../../auth/decorator/customer.decorator';
-import { AuthGuard } from '@nestjs/passport';
+import { Auth, CurrentCustomer } from '../../../auth/decorator/auth.decorator';
 import { MetaData } from './image.dto';
 import { Customer } from '../../../schemas/customers.entity';
 import { PresignedUrlDto } from '../../cloud/aws/s3/presentation/presigned-url.dto';
@@ -46,9 +38,9 @@ export class ImageController {
     type: [PresignedUrlDto],
     description: 'Generated presigned URL',
   })
-  @Post('/presigned-url')
-  @UseGuards(AuthGuard())
+  @Auth()
   @HttpCode(201)
+  @Post('/presigned-url')
   async getPreSignedUrl(
     @CurrentCustomer() customer: Customer,
     @Query('key') key: string,

--- a/src/customer/presentation/customer.controller.ts
+++ b/src/customer/presentation/customer.controller.ts
@@ -1,16 +1,9 @@
 import { CustomerService } from '../application/customer.service';
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { AuthGuard } from '@nestjs/passport';
+import { Controller, Get } from '@nestjs/common';
 import { CustomerDto } from './customer.dto';
 import { Customer } from '../../schemas/customers.entity';
-import { CurrentCustomer } from '../../auth/decorator/customer.decorator';
-import {
-  ApiBearerAuth,
-  ApiOkResponse,
-  ApiOperation,
-  ApiTags,
-  ApiUnauthorizedResponse,
-} from '@nestjs/swagger';
+import { Auth, CurrentCustomer } from '../../auth/decorator/auth.decorator';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('고객 관련 API')
 @Controller('/v1/customer')
@@ -22,12 +15,7 @@ export class CustomerController {
     description: 'Access Token을 통해 내 정보를 조회합니다.',
   })
   @ApiOkResponse({ type: CustomerDto, description: '내 정보 조회 성공' })
-  @ApiUnauthorizedResponse({
-    description:
-      'Unauthorized / Access Token이 만료되었거나 잘못되었습니다. 토큰을 갱신하세요',
-  })
-  @ApiBearerAuth()
-  @UseGuards(AuthGuard())
+  @Auth()
   @Get('my')
   async getMyCustomer(
     @CurrentCustomer() customer: Customer,


### PR DESCRIPTION
## 🎫 X

- 🛠️ 코드 리팩토링

## 변경 사항에 대한 설명

applyDecorators를 활용하여 중복되어 사용되는
UserGuards, ApiBearAuth, ApiUnauthorizedResponse를 Auth 데코레이터로 하나로 묶어서 사용할 수 있도록 합니다.

## 테스트 방법

Swagger 확인 및 API 테스트
