### PR TITLE
fix: CustomerDto Validation Annotation 수정

### DIFF
--- a/src/customer/presentation/customer.dto.ts
+++ b/src/customer/presentation/customer.dto.ts
@@ -25,7 +25,7 @@ export class CustomerDto {
     type: String,
   })
   @IsNotEmpty()
-  @Length(1, 20)
+  @Length(1, 44)
   uuid: string;
 
   @ApiProperty({


### PR DESCRIPTION
## 🎫 X
- 🐛 버그 수정

## 변경 사항에 대한 설명

apple의 유저 식별자가 44자의 uuid로 처리되어 있어 dto의 Length annotation 수정했습니다.