### PR TITLE
DMVM-194 fix: 업체 로그인 API 구현

### DIFF
--- a/src/auth/application/auth.service.spec.ts
+++ b/src/auth/application/auth.service.spec.ts
@@ -1,18 +1,108 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { CacheService } from '../../common/cache/cache.service';
+import { UserService } from './user.service';
+import { AuthProvider, UserDto } from '../presentation/user.dto';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let jwtService: JwtService;
+  let configService: ConfigService;
+  let cacheService: CacheService;
+  let userService: UserService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: JwtService,
+          useValue: { sign: jest.fn(), decode: jest.fn(), verify: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        {
+          provide: CacheService,
+          useValue: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+        },
+        {
+          provide: UserService,
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            toUserDto: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
+    jwtService = module.get<JwtService>(JwtService);
+    configService = module.get<ConfigService>(ConfigService);
+    cacheService = module.get<CacheService>(CacheService);
+    userService = module.get<UserService>(UserService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('로그인하고 토큰을 반환', async () => {
+    const userDto: UserDto = {
+      uuid: 'test-uuid',
+      authProvider: AuthProvider.BASIC,
+    };
+
+    jest.spyOn(userService, 'findOne').mockResolvedValueOnce(null);
+    jest.spyOn(userService, 'create').mockResolvedValueOnce(userDto);
+    jest
+      .spyOn(jwtService, 'sign')
+      .mockReturnValueOnce('test-access-token')
+      .mockReturnValueOnce('test-refresh-token');
+    jest.spyOn(cacheService, 'set').mockResolvedValueOnce(undefined);
+    jest.spyOn(userService, 'update').mockResolvedValueOnce(userDto);
+
+    const result = await service.login(userDto);
+
+    expect(result).toEqual({
+      uuid: 'test-uuid',
+      authProvider: 'BASIC',
+      accessToken: 'test-access-token',
+      refreshToken: 'test-refresh-token',
+    });
+  });
+
+  it('토큰을 새로 고쳐야 함', async () => {
+    const req = {
+      headers: {
+        authorization: 'Bearer test-refresh-token',
+      },
+    };
+
+    const userDto: UserDto = {
+      uuid: 'test-uuid',
+      authProvider: AuthProvider.BASIC,
+    };
+
+    jest.spyOn(jwtService, 'decode').mockReturnValueOnce({
+      tokenType: 'refresh',
+      subject: 'test-uuid',
+      userType: 'customer',
+    });
+    jest.spyOn(userService, 'findOne').mockResolvedValueOnce(userDto);
+    jest.spyOn(userService, 'toUserDto').mockReturnValue(userDto);
+    jest
+      .spyOn(jwtService, 'sign')
+      .mockReturnValueOnce('test-new-access-token')
+      .mockReturnValueOnce('test-new-refresh-token');
+    jest.spyOn(cacheService, 'set').mockResolvedValueOnce('OK');
+    jest.spyOn(userService, 'update').mockResolvedValueOnce(userDto);
+
+    const result = await service.tokenRefresh(req as any);
+
+    expect(result).toEqual({
+      uuid: 'test-uuid',
+      authProvider: AuthProvider.BASIC,
+      accessToken: 'test-new-access-token',
+      refreshToken: 'test-new-refresh-token',
+    });
   });
 });

--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -125,7 +125,7 @@ export class AuthService {
   private async saveAccessToken(user: UserDto, accessToken: string) {
     const key = `${user.userType}:${user.userId}:accessToken`;
 
-    if (this.accessTokenStrategy.toLowerCase() === 'unique') {
+    if (this.accessTokenStrategy?.toLowerCase() === 'unique') {
       this.cacheService.get(key).then((v) => {
         if (v) {
           this.cacheService.del(v);

--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -71,7 +71,7 @@ export class AuthService {
       uuid: user.uuid,
       name: user.name,
       userId: user.userId,
-      userType: user.userType,
+      userType: user.userType ?? dto.userType,
       phoneNumber: user.phoneNumber,
       authProvider: user.authProvider,
       accessToken: accessToken,

--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -1,28 +1,23 @@
 import { Injectable } from '@nestjs/common';
-import { CustomerService } from 'src/customer/application/customer.service';
-import { Customer } from 'src/schemas/customers.entity';
 import { JwtService, JwtSignOptions } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { CacheService } from '../../common/cache/cache.service';
-import { CustomerDto } from '../../customer/presentation/customer.dto';
 import { UnauthorizedException } from '@nestjs/common/exceptions';
-import { DriverService } from '../../driver/application/driver.service';
-import { BusinessService } from '../../business/application/business.service';
+import { UserService } from './user.service';
+import { UserDto } from '../presentation/user.dto';
+import { AuthDto } from '../presentation/auth.dto';
 
 @Injectable()
 export class AuthService {
   private readonly accessTokenOption: JwtSignOptions;
   private readonly refreshTokenOption: JwtSignOptions;
   private readonly accessTokenStrategy: string;
-  private readonly userServices = {};
 
   constructor(
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly cacheService: CacheService,
-    private readonly customerService: CustomerService,
-    private readonly driverService: DriverService,
-    private readonly businessService: BusinessService,
+    private readonly userService: UserService,
   ) {
     this.accessTokenOption = {
       secret: this.configService.get<string>('jwt/access/secret'),
@@ -37,67 +32,68 @@ export class AuthService {
     this.accessTokenStrategy = this.configService.get<string>(
       'jwt/access/strategy',
     );
-
-    this.userServices['customer'] = customerService;
-    this.userServices['driver'] = driverService;
-    this.userServices['business'] = businessService;
   }
 
-  async login(dto: CustomerDto): Promise<CustomerDto> {
-    let customer: Customer = await this.customerService.findOne(dto);
-    customer = customer ?? (await this.customerService.create(dto));
+  async login(dto: UserDto): Promise<AuthDto> {
+    let user: UserDto = await this.userService.findOne(dto);
+    user = user ?? (await this.userService.create(dto));
+
+    user.userId = user['customerId'] ?? user['driverId'] ?? user['businessId'];
+    user.userType = dto.userType;
 
     const accessToken = this.jwtService.sign(
       {
         tokenType: 'access',
-        subject: customer.customerId,
-        userType: 'customer',
+        subject: user.userId,
+        userType: user.userType,
       },
       this.accessTokenOption,
     );
 
-    await this.saveAccessToken(customer, accessToken);
+    await this.saveAccessToken(user, accessToken);
 
     const refreshToken = this.jwtService.sign(
       {
         tokenType: 'refresh',
-        subject: customer.customerId,
-        userType: 'customer',
+        subject: user.userId,
+        userType: user.userType,
       },
       this.refreshTokenOption,
     );
 
-    await this.customerService.update({
-      ...customer,
+    await this.userService.update({
+      ...user,
+      userType: user.userType,
       refreshToken: refreshToken,
     });
 
     return {
-      customerId: customer.customerId,
-      uuid: customer.uuid,
-      customerName: customer.customerName,
-      customerPhoneNumber: customer.customerPhoneNumber,
-      customerLocation: customer.customerLocation,
-      authProvider: customer.authProvider,
+      uuid: user.uuid,
+      name: user.name,
+      userId: user.userId,
+      userType: user.userType,
+      phoneNumber: user.phoneNumber,
+      authProvider: user.authProvider,
       accessToken: accessToken,
       refreshToken: refreshToken,
     };
   }
 
-  async tokenRefresh(request: Request): Promise<CustomerDto> {
+  async tokenRefresh(request: Request): Promise<AuthDto> {
     const token = request.headers['authorization'].replace('Bearer ', '');
 
     const payload = this.jwtService.decode(token);
 
-    const customer: Customer = await this.customerService.findOne({
+    const user: UserDto = await this.userService.findOne({
+      userType: payload.userType,
       userId: payload.subject,
     });
 
     const accessToken = this.jwtService.sign(
       {
         tokenType: 'access',
-        subject: customer.customerId,
-        userType: 'customer',
+        subject: user.userId,
+        userType: user.userType,
       },
       this.accessTokenOption,
     );
@@ -105,33 +101,29 @@ export class AuthService {
     const refreshToken = this.jwtService.sign(
       {
         tokenType: 'refresh',
-        subject: customer.customerId,
-        userType: 'customer',
+        subject: user.userId,
+        userType: user.userType,
       },
       this.refreshTokenOption,
     );
 
-    await this.saveAccessToken(customer, accessToken);
+    await this.saveAccessToken(user, accessToken);
 
-    await this.customerService.update({
-      ...customer,
+    await this.userService.update({
+      ...user,
       refreshToken: refreshToken,
     });
 
+    const userDto = this.userService.toUserDto(user);
     return {
-      customerId: customer.customerId,
-      uuid: customer.uuid,
-      customerName: customer.customerName,
-      customerPhoneNumber: customer.customerPhoneNumber,
-      customerLocation: customer.customerLocation,
-      authProvider: customer.authProvider,
+      ...userDto,
       accessToken: accessToken,
       refreshToken: refreshToken,
     };
   }
 
-  private async saveAccessToken(customer: Customer, accessToken: string) {
-    const key = `customer:${customer.customerId}:accessToken`;
+  private async saveAccessToken(user: UserDto, accessToken: string) {
+    const key = `${user.userType}:${user.userId}:accessToken`;
 
     if (this.accessTokenStrategy.toLowerCase() === 'unique') {
       this.cacheService.get(key).then((v) => {
@@ -150,7 +142,7 @@ export class AuthService {
     await this.cacheService.set(
       accessToken,
       JSON.stringify({
-        ...customer,
+        ...user,
         refreshToken: undefined,
       }),
       (this.accessTokenOption.expiresIn as number) / 1000,
@@ -167,7 +159,8 @@ export class AuthService {
       throw new UnauthorizedException();
     }
 
-    return await this.userServices[payload.userType].findOne({
+    return await this.userService.findOne({
+      userType: payload.userType,
       userId: payload.subject,
     });
   }

--- a/src/auth/application/jwt-access.strategy.ts
+++ b/src/auth/application/jwt-access.strategy.ts
@@ -6,8 +6,8 @@ import {
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { Customer } from '../../schemas/customers.entity';
 import { CacheService } from '../../common/cache/cache.service';
+import { UserDto } from '../presentation/user.dto';
 
 @Injectable()
 export class JwtAccessStrategy extends PassportStrategy(Strategy, 'access') {
@@ -22,7 +22,7 @@ export class JwtAccessStrategy extends PassportStrategy(Strategy, 'access') {
     });
   }
 
-  async validate(req: Request, payload: any): Promise<Customer> {
+  async validate(req: Request, payload: any): Promise<UserDto> {
     if (!payload) {
       throw new UnauthorizedException();
     }
@@ -32,6 +32,6 @@ export class JwtAccessStrategy extends PassportStrategy(Strategy, 'access') {
     }
 
     const token = req.headers['authorization'].replace('Bearer ', '');
-    return JSON.parse(await this.cacheService.get(token)) as Customer;
+    return JSON.parse(await this.cacheService.get(token)) as UserDto;
   }
 }

--- a/src/auth/application/jwt-refresh.strategy.ts
+++ b/src/auth/application/jwt-refresh.strategy.ts
@@ -7,22 +7,35 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy, ExtractJwt } from 'passport-jwt';
 import { CustomerService } from 'src/customer/application/customer.service';
-import { Customer } from '../../schemas/customers.entity';
+import { BusinessService } from '../../business/application/business.service';
+import { DriverService } from '../../driver/application/driver.service';
+import { IUserService } from '../user.interface';
+import { UserDto } from '../presentation/user.dto';
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
+  private readonly userServices: {
+    [key: string]: IUserService;
+  } = {};
+
   constructor(
     private readonly configService: ConfigService,
     private readonly customerService: CustomerService,
+    private readonly businessService: BusinessService,
+    private readonly driverService: DriverService,
   ) {
     super({
       secretOrKey: configService.get<string>('jwt/refresh/secret'),
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       passReqToCallback: true,
     });
+
+    this.userServices.customer = customerService;
+    this.userServices.business = businessService;
+    this.userServices.driver = driverService;
   }
 
-  async validate(req: Request, payload: any): Promise<Customer> {
+  async validate(req: Request, payload: any): Promise<UserDto> {
     if (!payload) {
       throw new UnauthorizedException();
     }
@@ -31,7 +44,8 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
       throw new BadRequestException();
     }
 
-    const token = req.headers['authorization'].replace('Bearer ', '');
-    return await this.customerService.findOne({ refreshToken: token });
+    return await this.userServices[payload.userType].findOne({
+      userId: payload.subject,
+    });
   }
 }

--- a/src/auth/application/user.service.ts
+++ b/src/auth/application/user.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { IUserService } from '../user.interface';
+import { CustomerService } from '../../customer/application/customer.service';
+import { DriverService } from '../../driver/application/driver.service';
+import { BusinessService } from '../../business/application/business.service';
+import { UserDto } from '../presentation/user.dto';
+import { AuthDto } from '../presentation/auth.dto';
+
+@Injectable()
+export class UserService {
+  private readonly userServices: {
+    [key: string]: IUserService;
+  } = {};
+
+  constructor(
+    private readonly customerService: CustomerService,
+    private readonly driverService: DriverService,
+    private readonly businessService: BusinessService,
+  ) {
+    this.userServices.customer = customerService;
+    this.userServices.driver = driverService;
+    this.userServices.business = businessService;
+  }
+
+  async findOne(dto: UserDto): Promise<any> {
+    const user = await this.userServices[dto.userType].findOne(dto);
+
+    user && (user.userType = dto.userType);
+    return user;
+  }
+
+  async create(dto: UserDto) {
+    return this.userServices[dto.userType].create(dto);
+  }
+
+  async update(dto: AuthDto) {
+    return await this.userServices[dto.userType].update(dto);
+  }
+
+  toUserDto(user: any) {
+    return this.userServices[user.userType].toUserDto(user);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { PassportModule } from '@nestjs/passport';
 import { CacheModule } from '../common/cache/cache.module';
 import { DriverModule } from '../driver/driver.module';
 import { BusinessModule } from '../business/business.module';
+import { UserModule } from './user.module';
 
 @Global()
 @Module({
@@ -21,13 +22,18 @@ import { BusinessModule } from '../business/business.module';
       inject: [ConfigService],
     }),
     PassportModule.register({ defaultStrategy: 'access' }),
+    UserModule,
     CacheModule,
     DriverModule,
     CustomerModule,
     BusinessModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtAccessStrategy, JwtRefreshStrategy],
+  providers: [
+    AuthService,
+    JwtAccessStrategy,
+    JwtRefreshStrategy
+  ],
   exports: [AuthService, JwtAccessStrategy, JwtRefreshStrategy, PassportModule],
 })
 export class AuthModule {}

--- a/src/auth/decorator/auth.decorator.ts
+++ b/src/auth/decorator/auth.decorator.ts
@@ -9,10 +9,26 @@ import {
 import { Customer } from '../../schemas/customers.entity';
 import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { Business } from '../../schemas/business.entity';
+import { Driver } from '../../schemas/drivers.entity';
 
 export const CurrentCustomer = createParamDecorator(
   (data: unknown, context: ExecutionContext) => {
     const req: { user?: Customer } = context.switchToHttp().getRequest();
+    return req.user;
+  },
+);
+
+export const CurrentBusiness = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const req: { user?: Business } = context.switchToHttp().getRequest();
+    return req.user;
+  },
+);
+
+export const CurrentDriver = createParamDecorator(
+  (data: unknown, context: ExecutionContext) => {
+    const req: { user?: Driver } = context.switchToHttp().getRequest();
     return req.user;
   },
 );

--- a/src/auth/decorator/auth.decorator.ts
+++ b/src/auth/decorator/auth.decorator.ts
@@ -2,6 +2,7 @@ import {
   applyDecorators,
   createParamDecorator,
   ExecutionContext,
+  ForbiddenException,
   HttpCode,
   HttpStatus,
   UseGuards,
@@ -15,6 +16,10 @@ import { Driver } from '../../schemas/drivers.entity';
 export const CurrentCustomer = createParamDecorator(
   (data: unknown, context: ExecutionContext) => {
     const req: { user?: Customer } = context.switchToHttp().getRequest();
+
+    if (!req.user.customerId) {
+      throw new ForbiddenException('해당 계정은 고객 계정이 아닙니다.');
+    }
     return req.user;
   },
 );
@@ -22,6 +27,10 @@ export const CurrentCustomer = createParamDecorator(
 export const CurrentBusiness = createParamDecorator(
   (data: unknown, context: ExecutionContext) => {
     const req: { user?: Business } = context.switchToHttp().getRequest();
+
+    if (!req.user.businessId) {
+      throw new ForbiddenException('해당 계정은 업체 계정이 아닙니다.');
+    }
     return req.user;
   },
 );
@@ -29,6 +38,10 @@ export const CurrentBusiness = createParamDecorator(
 export const CurrentDriver = createParamDecorator(
   (data: unknown, context: ExecutionContext) => {
     const req: { user?: Driver } = context.switchToHttp().getRequest();
+
+    if (!req.user.driverId) {
+      throw new ForbiddenException('해당 계정은 기사 계정이 아닙니다.');
+    }
     return req.user;
   },
 );

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -7,8 +7,8 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { CustomerDto } from '../../customer/presentation/customer.dto';
 import { Auth } from '../decorator/auth.decorator';
+import { UserDto } from './user.dto';
 
 @ApiTags('인증 관련 API')
 @Controller('/v1/auth')
@@ -26,7 +26,7 @@ export class AuthController {
     description: `Unauthorized / 요청한 Access Token이 만료되었습니다. 토큰을 갱신하세요`,
   })
   @Post('/login')
-  async login(@Body() dto: CustomerDto) {
+  async login(@Body() dto: UserDto) {
     return await this.authService.login(dto);
   }
 
@@ -42,7 +42,7 @@ export class AuthController {
   })
   @Auth(HttpStatus.CREATED, 'refresh')
   @Post('/refresh')
-  async refresh(@Req() req: Request): Promise<CustomerDto> {
+  async refresh(@Req() req: Request): Promise<UserDto> {
     return await this.authService.tokenRefresh(req);
   }
 }

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -8,7 +8,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { Auth } from '../decorator/auth.decorator';
-import { UserDto } from './user.dto';
+import { UserDto, UserGroup } from './user.dto';
+import { GroupValidation } from '../../common/validation/validation.decorator';
 
 @ApiTags('인증 관련 API')
 @Controller('/v1/auth')
@@ -26,7 +27,8 @@ export class AuthController {
     description: `Unauthorized / 요청한 Access Token이 만료되었습니다. 토큰을 갱신하세요`,
   })
   @Post('/login')
-  async login(@Body() dto: UserDto) {
+  @GroupValidation([UserGroup.login])
+  async login(@Body() dto: UserDto): Promise<AuthDto> {
     return await this.authService.login(dto);
   }
 
@@ -42,7 +44,7 @@ export class AuthController {
   })
   @Auth(HttpStatus.CREATED, 'refresh')
   @Post('/refresh')
-  async refresh(@Req() req: Request): Promise<UserDto> {
+  async refresh(@Req() req: Request): Promise<AuthDto> {
     return await this.authService.tokenRefresh(req);
   }
 }

--- a/src/auth/presentation/auth.dto.ts
+++ b/src/auth/presentation/auth.dto.ts
@@ -15,5 +15,5 @@ export class AuthDto extends UserDto {
     type: String,
   })
   @IsOptional()
-  refreshToken: string;
+  refreshToken?: string;
 }

--- a/src/auth/presentation/user.dto.ts
+++ b/src/auth/presentation/user.dto.ts
@@ -1,7 +1,16 @@
 import { IsNotEmpty, IsOptional } from 'class-validator';
 import { Group } from '../../common/validation/validation.data';
 
+export enum AuthProvider {
+  KAKAO = 'KAKAO',
+  APPLE = 'APPLE',
+  GOOGLE = 'GOOGLE',
+  BASIC = 'BASIC',
+}
+
 export class UserDto {
+  authProvider?: AuthProvider;
+
   @IsNotEmpty({ groups: [Group.create] })
   @IsOptional()
   userType?: UserType;
@@ -9,6 +18,7 @@ export class UserDto {
   @IsNotEmpty({ groups: [Group.create] })
   @IsOptional()
   userId?: number;
+  phoneNumber?: string;
   uuid?: string;
   name?: string;
 }

--- a/src/auth/presentation/user.dto.ts
+++ b/src/auth/presentation/user.dto.ts
@@ -1,5 +1,13 @@
-import { IsNotEmpty, IsOptional } from 'class-validator';
-import { Group } from '../../common/validation/validation.data';
+import { IsIn, IsNotEmpty, IsOptional } from 'class-validator';
+import { CrudGroup } from '../../common/validation/validation.data';
+
+// 고객, 업체, 기사 공통 사용 DTO
+export type UserType = 'customer' | 'driver' | 'business';
+
+// UserDtoValidationGroup
+export enum UserGroup {
+  login = 'login',
+}
 
 export enum AuthProvider {
   KAKAO = 'KAKAO',
@@ -11,17 +19,15 @@ export enum AuthProvider {
 export class UserDto {
   authProvider?: AuthProvider;
 
-  @IsNotEmpty({ groups: [Group.create] })
+  @IsIn(['customer', 'driver', 'business'], { groups: [UserGroup.login] })
   @IsOptional()
+  @IsNotEmpty({ groups: [UserGroup.login] })
   userType?: UserType;
 
-  @IsNotEmpty({ groups: [Group.create] })
+  @IsNotEmpty({ groups: [CrudGroup.create] })
   @IsOptional()
   userId?: number;
   phoneNumber?: string;
   uuid?: string;
   name?: string;
 }
-
-// 고객, 업체, 기사 공통 사용 DTO
-export type UserType = 'customer' | 'driver' | 'business';

--- a/src/auth/presentation/user.dto.ts
+++ b/src/auth/presentation/user.dto.ts
@@ -1,5 +1,6 @@
 import { IsIn, IsNotEmpty, IsOptional } from 'class-validator';
 import { CrudGroup } from '../../common/validation/validation.data';
+import { ApiProperty } from '@nestjs/swagger';
 
 // 고객, 업체, 기사 공통 사용 DTO
 export type UserType = 'customer' | 'driver' | 'business';
@@ -17,17 +18,45 @@ export enum AuthProvider {
 }
 
 export class UserDto {
+  @ApiProperty({
+    description: '인증 제공자 타입',
+    required: true,
+  })
   authProvider?: AuthProvider;
 
+  @ApiProperty({
+    description: '사용자가 고객인지, 기사인지, 업체인지 확인하는 타입입니다.',
+    required: true,
+  })
   @IsIn(['customer', 'driver', 'business'], { groups: [UserGroup.login] })
   @IsOptional()
   @IsNotEmpty({ groups: [UserGroup.login] })
   userType?: UserType;
 
+  @ApiProperty({
+    description:
+      '사용자 ID입니다 userType에 따라 customerId, driverId, businessId로 될 수 있으며 UserDto에선 userId로 통일합니다.',
+    required: false,
+  })
   @IsNotEmpty({ groups: [CrudGroup.create] })
   @IsOptional()
   userId?: number;
+
+  @ApiProperty({
+    description:
+      '사용자 전화번호입니다. 현재는 customer, business에서만 사용합니다.',
+    required: false,
+  })
   phoneNumber?: string;
+
+  @ApiProperty({
+    description: '사용자 UUID입니다.',
+    required: false,
+  })
   uuid?: string;
+
+  @ApiProperty({
+    description: '사용자 이름입니다.',
+  })
   name?: string;
 }

--- a/src/auth/user.interface.ts
+++ b/src/auth/user.interface.ts
@@ -1,5 +1,14 @@
-import { UserDto } from './presentation/user.dto';
+import { UserDto, UserType } from './presentation/user.dto';
+import { AuthDto } from './presentation/auth.dto';
 
 export interface IUserService {
-  findOne(dto: Partial<UserDto>): Promise<UserDto>;
+  readonly userType: UserType;
+
+  findOne(dto: Partial<AuthDto>): Promise<UserDto>;
+
+  create(dto: UserDto): Promise<UserDto>;
+
+  update(dto: UserDto): Promise<UserDto>;
+
+  toUserDto(user: any): UserDto;
 }

--- a/src/auth/user.module.ts
+++ b/src/auth/user.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './application/user.service';
+import { CustomerModule } from '../customer/customer.module';
+import { BusinessModule } from '../business/business.module';
+import { DriverModule } from '../driver/driver.module';
+
+@Module({
+  imports: [CustomerModule, BusinessModule, DriverModule],
+  controllers: [],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/src/business/application/business.service.spec.ts
+++ b/src/business/application/business.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BusinessService } from './business.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Business } from '../../schemas/business.entity';
+import { Repository } from 'typeorm';
+import { AuthProvider } from '../../auth/presentation/user.dto';
+
+describe('BusinessService', () => {
+  let service: BusinessService;
+  let repo: Repository<Business>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BusinessService,
+        {
+          provide: getRepositoryToken(Business),
+          useClass: Repository<Business>,
+        },
+      ],
+    }).compile();
+
+    service = module.get<BusinessService>(BusinessService);
+    repo = module.get<Repository<Business>>(getRepositoryToken(Business));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('업체 조회', async () => {
+    const business = new Business();
+    business.businessId = 1;
+    business.businessName = 'test';
+    business.uuid = 'test';
+    business.authProvider = AuthProvider.BASIC;
+
+    jest.spyOn(repo, 'findOne').mockResolvedValueOnce(business);
+
+    expect(await service.findOne({ userId: 1 })).toEqual(business);
+  });
+
+  it('업체 계정 생성', async () => {
+    const business = new Business();
+    business.businessId = 1;
+    business.businessName = 'test';
+    business.uuid = 'test';
+    business.authProvider = AuthProvider.BASIC;
+
+    jest.spyOn(repo, 'create').mockReturnValueOnce(business);
+    jest.spyOn(repo, 'save').mockResolvedValueOnce(business);
+
+    expect(
+      await service.create({
+        uuid: 'test',
+        name: 'test',
+        userType: 'business',
+        phoneNumber: '0101111111',
+        authProvider: AuthProvider.BASIC,
+      }),
+    ).toEqual(business);
+  });
+
+  it('업체 정보 수정', async () => {
+    const business = new Business();
+    business.businessId = 1;
+    business.businessName = 'test';
+    business.uuid = 'test';
+    business.authProvider = AuthProvider.BASIC;
+
+    const updatedBusiness = new Business();
+    updatedBusiness.businessId = 1;
+    updatedBusiness.businessName = 'updated test';
+    updatedBusiness.uuid = 'test';
+    updatedBusiness.authProvider = AuthProvider.BASIC;
+
+    jest.spyOn(repo, 'findOne').mockResolvedValueOnce(business);
+    jest.spyOn(repo, 'save').mockResolvedValueOnce(updatedBusiness);
+
+    expect(
+      await service.update({
+        userId: 1,
+        name: 'updated test',
+        phoneNumber: '0101111111',
+      }),
+    ).toEqual(updatedBusiness);
+  });
+});

--- a/src/business/application/business.service.ts
+++ b/src/business/application/business.service.ts
@@ -1,30 +1,69 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { IUserService } from '../../auth/user.interface';
-import { UserDto } from '../../auth/presentation/user.dto';
+import { UserDto, UserType } from '../../auth/presentation/user.dto';
 import { Business } from '../../schemas/business.entity';
+import { AuthDto } from '../../auth/presentation/auth.dto';
+import { Customer } from '../../schemas/customers.entity';
 
 @Injectable()
 export class BusinessService implements IUserService {
+  readonly userType: UserType = 'business';
+  private readonly logger = new Logger(BusinessService.name);
+
   constructor(
     @InjectRepository(Business)
     private readonly businessRepository: Repository<Business>,
   ) {}
 
-  async signUp(dto: Business): Promise<Business> {
-    const newDriver = this.businessRepository.create(dto);
-    return await this.businessRepository.save(newDriver);
-  }
-
-  async findOne(dto: Partial<UserDto>): Promise<Business> {
+  async findOne(dto: Partial<AuthDto>): Promise<Business> {
     const where = {};
 
-    dto.userId && (where['driverId'] = dto.userId);
+    dto.userId && (where['businessId'] = dto.userId ?? dto['businessId']);
     dto.uuid && (where['uuid'] = dto.uuid);
 
     return await this.businessRepository.findOne({
       where: where,
     });
+  }
+
+  async create(dto: UserDto): Promise<Business> {
+    const business = new Business();
+    business.uuid = dto.uuid;
+    business.businessName = dto.name;
+    business.authProvider = dto.authProvider;
+
+    return await this.businessRepository
+      .save(this.businessRepository.create(business))
+      .then((newBusiness) => {
+        this.logger.log(
+          `Create new business id:${newBusiness.businessId}, name:${newBusiness.businessName}`,
+        );
+        return newBusiness;
+      });
+  }
+
+  async update(dto: AuthDto): Promise<Business> {
+    return this.findOne(dto).then(async (business) => {
+      if (business) {
+        business.businessName = dto.name;
+        business.businessPhoneNumber = dto.phoneNumber;
+        business.refreshToken = dto.refreshToken ?? business.refreshToken;
+
+        return await this.businessRepository.save(business);
+      }
+    });
+  }
+
+  toUserDto(business: Business): UserDto {
+    return {
+      uuid: business.uuid,
+      name: business.businessName,
+      userId: business.businessId,
+      userType: this.userType,
+      phoneNumber: business.businessPhoneNumber,
+      authProvider: business.authProvider,
+    };
   }
 }

--- a/src/business/application/business.service.ts
+++ b/src/business/application/business.service.ts
@@ -5,7 +5,6 @@ import { IUserService } from '../../auth/user.interface';
 import { UserDto, UserType } from '../../auth/presentation/user.dto';
 import { Business } from '../../schemas/business.entity';
 import { AuthDto } from '../../auth/presentation/auth.dto';
-import { Customer } from '../../schemas/customers.entity';
 
 @Injectable()
 export class BusinessService implements IUserService {

--- a/src/business/business.module.ts
+++ b/src/business/business.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BusinessService } from './application/business.service';
 import { Business } from '../schemas/business.entity';
+import { BusinessController } from './presentation/business.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Business])],
   exports: [BusinessService],
   providers: [BusinessService],
+  controllers: [BusinessController],
 })
 export class BusinessModule {}

--- a/src/business/presentation/business.controller.spect.ts
+++ b/src/business/presentation/business.controller.spect.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BusinessController } from './business.controller';
+import { BusinessService } from '../application/business.service';
+import { Business } from '../../schemas/business.entity';
+import { AuthProvider } from '../../auth/presentation/user.dto';
+import { CurrentBusiness } from '../../auth/decorator/auth.decorator';
+import { ForbiddenException } from '@nestjs/common';
+
+describe('BusinessController', () => {
+  let controller: BusinessController;
+  let businessService: BusinessService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BusinessController],
+      providers: [
+        {
+          provide: BusinessService,
+          useValue: {
+            // 필요한 서비스 메서드를 모킹
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<BusinessController>(BusinessController);
+    businessService = module.get<BusinessService>(BusinessService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('내 업체 정보 조회', () => {
+    it('인증되면 비즈니스 정보를 반환', async () => {
+      const mockBusiness = new Business();
+      mockBusiness.businessId = 1;
+      mockBusiness.businessName = 'Test Business';
+      mockBusiness.uuid = 'test-uuid';
+      mockBusiness.authProvider = AuthProvider.BASIC;
+      mockBusiness.openingDate = new Date();
+      mockBusiness.businessRule = 'Rule';
+
+      jest.spyOn(businessService, 'findOne').mockResolvedValue(mockBusiness);
+
+      const result = await controller.getMyBusinessInfo(mockBusiness);
+
+      expect(result).toEqual({
+        uuid: 'test-uuid',
+        authProvider: 'local',
+        openingDate: mockBusiness.openingDate,
+        businessId: 1,
+        businessName: 'Test Business',
+        businessRule: 'Rule',
+      });
+    });
+
+    it('사용자가 비즈니스가 아닌 경우 금지된 예외를 던져야 함\n', () => {
+      const mockBusiness = new Business();
+      mockBusiness.businessId = 1;
+      mockBusiness.businessName = 'Test Business';
+      mockBusiness.uuid = 'test-uuid';
+      mockBusiness.authProvider = AuthProvider.BASIC;
+      mockBusiness.openingDate = new Date();
+      mockBusiness.businessRule = 'Rule';
+
+      expect(() =>
+        CurrentBusiness(null, {
+          switchToHttp: () => ({
+            getRequest: () => ({ user: mockBusiness }),
+          }),
+        } as any),
+      ).toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/business/presentation/business.controller.ts
+++ b/src/business/presentation/business.controller.ts
@@ -1,0 +1,36 @@
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Controller, Get } from '@nestjs/common';
+import { CustomerDto } from '../../customer/presentation/customer.dto';
+import { Auth, CurrentBusiness } from '../../auth/decorator/auth.decorator';
+import { Business } from '../../schemas/business.entity';
+import { BusinessService } from '../application/business.service';
+import { BusinessDto } from './business.dto';
+
+@ApiTags('업체 관련 API')
+@Controller('/v1/business')
+export class BusinessController {
+  constructor(private readonly businessService: BusinessService) {}
+
+  @ApiOperation({
+    summary: '업체 정보 조회',
+    description: 'Access Token을 통해 내 정보를 조회합니다.',
+  })
+  @ApiOkResponse({ type: CustomerDto, description: '내 정보 조회 성공' })
+  @Auth()
+  @Get('my')
+  async getMyCustomer(
+    @CurrentBusiness() business: Business,
+  ): Promise<BusinessDto> {
+    return {
+      uuid: business.uuid,
+      authProvider: business.authProvider,
+      openingDate: business.openingDate,
+      businessId: business.businessId,
+      businessName: business.businessName,
+      businessRule: business.businessRule,
+      businessLocation: business.businessLocation,
+      businessPriceGuide: business.businessPriceGuide,
+      businessPhoneNumber: business.businessPhoneNumber,
+    };
+  }
+}

--- a/src/business/presentation/business.controller.ts
+++ b/src/business/presentation/business.controller.ts
@@ -18,7 +18,7 @@ export class BusinessController {
   @ApiOkResponse({ type: CustomerDto, description: '내 정보 조회 성공' })
   @Auth()
   @Get('my')
-  async getMyCustomer(
+  async getMyBusinessInfo(
     @CurrentBusiness() business: Business,
   ): Promise<BusinessDto> {
     return {

--- a/src/business/presentation/business.dto.ts
+++ b/src/business/presentation/business.dto.ts
@@ -1,0 +1,95 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsEnum,
+  Length,
+  IsNumber,
+} from 'class-validator';
+import { Point } from 'typeorm';
+;
+import { ApiProperty } from '@nestjs/swagger';
+import { AuthDto } from '../../auth/presentation/auth.dto';
+import { AuthProvider } from "../../auth/presentation/user.dto";
+
+export class BusinessDto extends AuthDto {
+  @ApiProperty({
+    description: 'Mongle Server에서의 업체 식별자',
+    required: false,
+    readOnly: true,
+  })
+  @IsNumber()
+  @IsOptional()
+  businessId?: number;
+
+  @ApiProperty({
+    description: 'ResourceServer에서 제공한 업체 식별자',
+    required: true,
+    type: String,
+  })
+  @IsNotEmpty()
+  @Length(1, 44)
+  uuid: string;
+
+  @ApiProperty({
+    description: '업체 이름',
+    required: true,
+    type: String,
+  })
+  @IsNotEmpty()
+  @Length(1, 30)
+  businessName: string;
+
+  @ApiProperty({
+    description: '업체 전화번호',
+    nullable: true,
+    required: false,
+    type: String,
+  })
+  @IsOptional()
+  @Length(1, 30)
+  businessPhoneNumber?: string;
+
+  @ApiProperty({
+    description: '업체 위치',
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  businessLocation?: Point;
+
+  @ApiProperty({
+    description: '업체 가격 가이드',
+    nullable: true,
+    required: false,
+    type: String,
+  })
+  @IsOptional()
+  @Length(1, 30)
+  businessPriceGuide: string;
+
+  @ApiProperty({
+    description: '업체 규칙',
+    nullable: true,
+    required: false,
+    type: String,
+  })
+  @IsOptional()
+  @Length(1, 30)
+  businessRule: string;
+
+  @ApiProperty({
+    description: '업체 오픈일',
+    nullable: true,
+    required: false,
+  })
+  @IsOptional()
+  openingDate: Date;
+
+  @ApiProperty({
+    description: '인증 제공자 타입',
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsEnum(AuthProvider)
+  authProvider: AuthProvider;
+}

--- a/src/business/presentation/business.dto.ts
+++ b/src/business/presentation/business.dto.ts
@@ -4,12 +4,13 @@ import {
   IsEnum,
   Length,
   IsNumber,
+  ValidateIf,
 } from 'class-validator';
 import { Point } from 'typeorm';
-;
 import { ApiProperty } from '@nestjs/swagger';
 import { AuthDto } from '../../auth/presentation/auth.dto';
-import { AuthProvider } from "../../auth/presentation/user.dto";
+import { AuthProvider, UserGroup } from '../../auth/presentation/user.dto';
+import { CRUD } from '../../common/validation/validation.data';
 
 export class BusinessDto extends AuthDto {
   @ApiProperty({
@@ -19,6 +20,7 @@ export class BusinessDto extends AuthDto {
   })
   @IsNumber()
   @IsOptional()
+  @ValidateIf((o) => !o.uuid, { groups: CRUD })
   businessId?: number;
 
   @ApiProperty({
@@ -26,8 +28,10 @@ export class BusinessDto extends AuthDto {
     required: true,
     type: String,
   })
-  @IsNotEmpty()
-  @Length(1, 44)
+  @Length(1, 44, { groups: CRUD })
+  @IsNotEmpty({ groups: CRUD })
+  @IsOptional()
+  @ValidateIf((o) => !o.businessId, { groups: CRUD })
   uuid: string;
 
   @ApiProperty({
@@ -90,6 +94,7 @@ export class BusinessDto extends AuthDto {
     required: true,
   })
   @IsNotEmpty()
-  @IsEnum(AuthProvider)
+  @IsOptional()
+  @IsEnum(AuthProvider, { groups: [UserGroup.login] })
   authProvider: AuthProvider;
 }

--- a/src/chat/presentation/chat.controller.ts
+++ b/src/chat/presentation/chat.controller.ts
@@ -10,7 +10,7 @@ import {
 import { ChatService } from '../application/chat.service';
 import { Auth, CurrentCustomer } from '../../auth/decorator/auth.decorator';
 import { Customer } from '../../schemas/customers.entity';
-import { Group } from '../../common/validation/validation.data';
+import { CrudGroup } from '../../common/validation/validation.data';
 import { GroupValidation } from '../../common/validation/validation.decorator';
 import { CursorDto } from '../../common/dto/cursor.dto';
 import { ChatMessageDto, ChatRoomDto } from './chat.dto';
@@ -38,7 +38,7 @@ export class ChatController {
   })
   @Auth(HttpStatus.CREATED)
   @Post()
-  @GroupValidation([Group.create])
+  @GroupValidation([CrudGroup.create])
   async createChat(
     @Body() chatRoom: ChatRoomDto,
     @CurrentCustomer() customer: Customer,

--- a/src/chat/presentation/chat.dto.ts
+++ b/src/chat/presentation/chat.dto.ts
@@ -9,7 +9,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { MessageType } from '../../schemas/chat-message.entity';
-import { Group, RUD } from '../../common/validation/validation.data';
+import { CrudGroup, RUD } from '../../common/validation/validation.data';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class ChatMessageDto {
@@ -105,7 +105,7 @@ export class ChatRoomDto {
     nullable: false,
     type: String,
   })
-  @IsNotEmpty({ groups: [Group.create] })
+  @IsNotEmpty({ groups: [CrudGroup.create] })
   @IsString()
   @IsOptional()
   public chatRoomName: string;
@@ -116,8 +116,8 @@ export class ChatRoomDto {
     required: false,
     type: UserDto,
   })
-  @IsNotEmpty({ groups: [Group.create] })
-  @ValidateNested({ groups: [Group.create] })
+  @IsNotEmpty({ groups: [CrudGroup.create] })
+  @ValidateNested({ groups: [CrudGroup.create] })
   @IsOptional()
   public inviteUser: UserDto;
 

--- a/src/common/validation/validation.data.ts
+++ b/src/common/validation/validation.data.ts
@@ -1,11 +1,21 @@
-export enum Group {
+import { UserGroup } from '../../auth/presentation/user.dto';
+
+export enum CrudGroup {
   create = 'create',
   read = 'read',
   update = 'update',
   delete = 'delete',
 }
 
-export const RUD = [Group.read, Group.update, Group.delete];
+export type Group = CrudGroup | UserGroup;
+
+export const RUD = [CrudGroup.read, CrudGroup.update, CrudGroup.delete];
+export const CRUD = [
+  CrudGroup.create,
+  CrudGroup.read,
+  CrudGroup.update,
+  CrudGroup.delete,
+];
 
 export const ValidationDefaultOption = {
   transform: true,

--- a/src/customer/application/customer.service.spec.ts
+++ b/src/customer/application/customer.service.spec.ts
@@ -1,18 +1,84 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CustomerService } from './customer.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Customer } from '../../schemas/customers.entity';
+import { Repository } from 'typeorm';
+import { AuthProvider } from '../../auth/presentation/user.dto';
 
 describe('CustomerService', () => {
   let service: CustomerService;
+  let repo: Repository<Customer>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CustomerService],
+      providers: [
+        CustomerService,
+        {
+          provide: getRepositoryToken(Customer),
+          useClass: Repository<Customer>,
+        },
+      ],
     }).compile();
 
     service = module.get<CustomerService>(CustomerService);
+    repo = module.get<Repository<Customer>>(getRepositoryToken(Customer));
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('should create a customer', async () => {
+    const customer = new Customer();
+    customer.customerId = 1;
+    customer.customerName = 'test';
+    customer.uuid = 'test';
+    customer.authProvider = AuthProvider.BASIC;
+
+    jest.spyOn(repo, 'create').mockReturnValueOnce(customer);
+    jest.spyOn(repo, 'save').mockResolvedValueOnce(customer);
+
+    expect(
+      await service.create({
+        uuid: 'test',
+        customerName: 'test',
+        userType: 'customer',
+        phoneNumber: '0101111111',
+        authProvider: AuthProvider.BASIC,
+      }),
+    ).toEqual(customer);
+  });
+
+  it('should find one customer', async () => {
+    const customer = new Customer();
+    customer.customerId = 1;
+    customer.customerName = 'test';
+    customer.uuid = 'test';
+    customer.authProvider = AuthProvider.BASIC;
+
+    jest.spyOn(repo, 'findOne').mockResolvedValueOnce(customer);
+
+    expect(await service.findOne({ userId: 1 })).toEqual(customer);
+  });
+
+  it('should update a customer', async () => {
+    const customer = new Customer();
+    customer.customerId = 1;
+    customer.customerName = 'test';
+    customer.uuid = 'test';
+    customer.authProvider = AuthProvider.BASIC;
+
+    const updatedCustomer = new Customer();
+    updatedCustomer.customerId = 1;
+    updatedCustomer.customerName = 'updated test';
+    updatedCustomer.uuid = 'test';
+    updatedCustomer.authProvider = AuthProvider.BASIC;
+
+    jest.spyOn(repo, 'findOne').mockResolvedValueOnce(customer);
+    jest.spyOn(repo, 'save').mockResolvedValueOnce(updatedCustomer);
+
+    expect(
+      await service.update({
+        userId: 1,
+        name: 'updated test',
+        phoneNumber: '0101111111',
+      }),
+    ).toEqual(updatedCustomer);
   });
 });

--- a/src/customer/application/customer.service.ts
+++ b/src/customer/application/customer.service.ts
@@ -5,17 +5,21 @@ import { Customer } from '../../schemas/customers.entity';
 import { CustomerDto } from '../presentation/customer.dto';
 import { IUserService } from '../../auth/user.interface';
 import { AuthDto } from '../../auth/presentation/auth.dto';
+import { UserDto, UserType } from '../../auth/presentation/user.dto';
 
 @Injectable()
 export class CustomerService implements IUserService {
+  readonly userType: UserType = 'customer';
+
   constructor(
     @InjectRepository(Customer)
     private customerRepository: Repository<Customer>,
   ) {}
 
   async create(dto: CustomerDto): Promise<Customer> {
-    const newCustomer = await this.customerRepository.create(dto);
-    return await this.customerRepository.save(newCustomer);
+    return await this.customerRepository.save(
+      this.customerRepository.create(dto),
+    );
   }
 
   async findOne(dto: Partial<AuthDto>): Promise<Customer> {
@@ -42,5 +46,16 @@ export class CustomerService implements IUserService {
         return await this.customerRepository.save(customer);
       }
     });
+  }
+
+  toUserDto(customer: Customer): UserDto {
+    return {
+      uuid: customer.uuid,
+      name: customer.customerName,
+      userId: customer.customerId,
+      userType: this.userType,
+      phoneNumber: customer.customerPhoneNumber,
+      authProvider: customer.authProvider,
+    };
   }
 }

--- a/src/customer/presentation/customer.controller.spec.ts
+++ b/src/customer/presentation/customer.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthController } from './auth.controller';
-import { AuthService } from '../application/auth.service';
-import { AuthProvider, UserDto } from './user.dto';
+import { AuthService } from '../../auth/application/auth.service';
+import { AuthController } from '../../auth/presentation/auth.controller';
+import { AuthProvider, UserDto } from '../../auth/presentation/user.dto';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -15,14 +15,10 @@ describe('AuthController', () => {
           provide: AuthService,
           useValue: {
             login: jest.fn().mockResolvedValue({
-              uuid: 'test-uuid',
-              authProvider: AuthProvider.BASIC,
               accessToken: 'test-access-token',
               refreshToken: 'test-refresh-token',
             }),
             tokenRefresh: jest.fn().mockResolvedValue({
-              uuid: 'test-uuid',
-              authProvider: AuthProvider.BASIC,
               accessToken: 'test-new-access-token',
               refreshToken: 'test-new-refresh-token',
             }),
@@ -35,7 +31,7 @@ describe('AuthController', () => {
     service = module.get<AuthService>(AuthService);
   });
 
-  it('로그인', async () => {
+  it('로그인하고 토큰을 반환', async () => {
     const userDto: UserDto = {
       uuid: 'test-uuid',
       authProvider: AuthProvider.BASIC,
@@ -44,8 +40,6 @@ describe('AuthController', () => {
     const result = await controller.login(userDto);
 
     expect(result).toEqual({
-      uuid: 'test-uuid',
-      authProvider: AuthProvider.BASIC,
       accessToken: 'test-access-token',
       refreshToken: 'test-refresh-token',
     });
@@ -62,8 +56,6 @@ describe('AuthController', () => {
     const result = await controller.refresh(req as any);
 
     expect(result).toEqual({
-      uuid: 'test-uuid',
-      authProvider: AuthProvider.BASIC,
       accessToken: 'test-new-access-token',
       refreshToken: 'test-new-refresh-token',
     });

--- a/src/customer/presentation/customer.dto.ts
+++ b/src/customer/presentation/customer.dto.ts
@@ -6,9 +6,9 @@ import {
   IsNumber,
 } from 'class-validator';
 import { Point } from 'typeorm';
-import { AuthProvider } from '../../schemas/customers.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { AuthDto } from '../../auth/presentation/auth.dto';
+import { AuthProvider } from '../../auth/presentation/user.dto';
 
 export class CustomerDto extends AuthDto {
   @ApiProperty({

--- a/src/driver/application/driver.service.ts
+++ b/src/driver/application/driver.service.ts
@@ -1,12 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Driver } from '../../schemas/drivers.entity';
 import { Repository } from 'typeorm';
 import { IUserService } from '../../auth/user.interface';
-import { UserDto } from '../../auth/presentation/user.dto';
+import { UserDto, UserType } from '../../auth/presentation/user.dto';
+import { AuthDto } from '../../auth/presentation/auth.dto';
 
 @Injectable()
 export class DriverService implements IUserService {
+  private readonly logger = new Logger(DriverService.name);
+
+  readonly userType: UserType = 'driver';
+
   constructor(
     @InjectRepository(Driver)
     private readonly driverRepository: Repository<Driver>,
@@ -17,14 +22,49 @@ export class DriverService implements IUserService {
     return await this.driverRepository.save(newDriver);
   }
 
-  async findOne(dto: Partial<UserDto>): Promise<Driver> {
+  async findOne(dto: Partial<AuthDto>): Promise<Driver> {
     const where = {};
 
     dto.userId && (where['driverId'] = dto.userId);
     dto.uuid && (where['uuid'] = dto.uuid);
+    dto.refreshToken && (where['refreshToken'] = dto.refreshToken);
 
     return await this.driverRepository.findOne({
       where: where,
     });
+  }
+
+  async create(dto: UserDto): Promise<Driver> {
+    return await this.driverRepository
+      .save(this.driverRepository.create(dto))
+      .then((driver) => {
+        this.logger.log(
+          `Create new driver id:${driver.driverId}, name:${driver.driverName}`,
+        );
+        return driver;
+      });
+  }
+
+  async update(dto: AuthDto): Promise<Driver> {
+    return this.findOne(dto).then(async (driver) => {
+      if (driver) {
+        driver.driverName = dto.name;
+        driver.driverPhoneNumber = dto.phoneNumber;
+        driver.refreshToken = dto.refreshToken ?? driver.refreshToken;
+
+        return await this.driverRepository.save(driver);
+      }
+    });
+  }
+
+  toUserDto(driver: Driver): UserDto {
+    return {
+      uuid: driver.uuid,
+      name: driver.driverName,
+      userId: driver.driverId,
+      userType: this.userType,
+      phoneNumber: driver.driverPhoneNumber,
+      authProvider: driver.authProvider,
+    };
   }
 }

--- a/src/schemas/business.entity.ts
+++ b/src/schemas/business.entity.ts
@@ -18,71 +18,90 @@ import { Review } from './reviews.entity';
 import { ServiceOption } from './service-options.entity';
 import { BusinessChatRoom } from './business-chat-room.entity';
 import { HasUuid } from '../common/entity/parent.entity';
+import { AuthProvider } from '../auth/presentation/user.dto';
 
 @Entity({ name: 'business' })
 export class Business extends HasUuid {
   @PrimaryColumn()
-  public businessId: number;
+  businessId: number;
 
-  @Column()
-  public businessName: string;
+  @Column({
+    nullable: false,
+  })
+  businessName: string;
 
-  @Column()
-  public businessPhoneNumber: string;
+  @Column({
+    nullable: true,
+  })
+  businessPhoneNumber: string;
 
   @Column({
     type: 'geometry',
     spatialFeatureType: 'Point',
     srid: 4326,
+  })
+  businessLocation: Point;
+
+  @Column({
     nullable: true,
   })
-  public businessLocation: Point;
+  businessPriceGuide: string;
 
-  @Column()
-  public businessPriceGuide: string;
+  @Column({
+    nullable: true,
+  })
+  businessRule: string;
 
-  @Column()
-  public businessRule: string;
-
-  @Column({ type: 'date' })
-  public openingDate: Date;
+  @Column({ type: 'date', nullable: true })
+  openingDate: Date;
 
   @CreateDateColumn()
-  public createdAt: Date;
+  createdAt: Date;
 
   @UpdateDateColumn()
-  public modifiedAt: Date;
+  modifiedAt: Date;
 
   @DeleteDateColumn()
-  public deletedAt: Date;
+  deletedAt: Date;
 
   @OneToMany(() => Favorite, (favorites) => favorites.business)
-  public favorites: Favorite[];
+  favorites: Favorite[];
 
   @OneToMany(() => Review, (reviews) => reviews.business)
-  public reviews: Review[];
+  reviews: Review[];
 
   @OneToMany(() => Appointment, (appointments) => appointments.business)
-  public appointments: Appointment[];
+  appointments: Appointment[];
 
   @OneToMany(() => Driver, (drivers) => drivers.business)
-  public drivers: Driver[];
+  drivers: Driver[];
 
   @OneToMany(() => ServiceOption, (serviceOptions) => serviceOptions.business)
-  public serviceOptions: ServiceOption[];
+  serviceOptions: ServiceOption[];
 
   @OneToMany(() => BusinessBadge, (businessBadges) => businessBadges.business)
-  public businessBadges: BusinessBadge[];
+  businessBadges: BusinessBadge[];
 
   @OneToMany(() => BusinessTag, (businessTags) => businessTags.business)
-  public businessTags: BusinessTag[];
+  businessTags: BusinessTag[];
 
   @OneToMany(
     () => BusinessNotice,
     (businessNotices) => businessNotices.business,
   )
-  public businessNotices: BusinessNotice[];
+  businessNotices: BusinessNotice[];
 
   @OneToMany(() => BusinessChatRoom, (chatRooms) => chatRooms.chatRoom)
-  public chatRooms: BusinessChatRoom[];
+  chatRooms: BusinessChatRoom[];
+
+  @Column({
+    type: 'enum',
+    enum: AuthProvider,
+    enumName: 'auth_provider',
+    nullable: false,
+  })
+  authProvider: AuthProvider;
+
+  @Column({ length: 20, unique: true, nullable: true })
+  refreshToken?: string;
 }

--- a/src/schemas/customers.entity.ts
+++ b/src/schemas/customers.entity.ts
@@ -14,11 +14,7 @@ import { Pet } from './pets.entity';
 import { Review } from './reviews.entity';
 import { CustomerChatRoom } from './customer-chat-room.entity';
 import { HasUuid } from '../common/entity/parent.entity';
-
-export enum AuthProvider {
-  KAKAO = 'KAKAO',
-  APPLE = 'APPLE',
-}
+import { AuthProvider } from '../auth/presentation/user.dto';
 
 @Entity({ name: 'customers' })
 export class Customer extends HasUuid {

--- a/src/schemas/drivers.entity.ts
+++ b/src/schemas/drivers.entity.ts
@@ -13,34 +13,46 @@ import { Appointment } from './appointments.entity';
 import { Business } from './business.entity';
 import { DriverChatRoom } from './driver-chat-room.entity';
 import { HasUuid } from '../common/entity/parent.entity';
+import { AuthProvider } from '../auth/presentation/user.dto';
 
 @Entity({ name: 'drivers' })
 export class Driver extends HasUuid {
   @PrimaryColumn()
-  public driverId: number;
+  driverId: number;
 
   @Column()
-  public driverName: string;
+  driverName: string;
 
   @Column()
-  public driverPhoneNumber: string;
+  driverPhoneNumber: string;
 
   @CreateDateColumn()
-  public createdAt: Date;
+  createdAt: Date;
 
   @UpdateDateColumn()
-  public modifiedAt: Date;
+  modifiedAt: Date;
 
   @DeleteDateColumn()
-  public deletedAt: Date;
+  deletedAt: Date;
 
   @OneToMany(() => Appointment, (appointments) => appointments.driver)
-  public appointments: Appointment[];
+  appointments: Appointment[];
 
   @OneToMany(() => DriverChatRoom, (chat) => chat.driver)
-  public chatRooms: DriverChatRoom[];
+  chatRooms: DriverChatRoom[];
 
   @ManyToOne(() => Business, (business) => business.drivers)
   @JoinColumn({ name: 'business_id' })
-  public business: Business;
+  business: Business;
+
+  @Column({
+    type: 'enum',
+    enum: AuthProvider,
+    enumName: 'auth_provider',
+    nullable: false,
+  })
+  authProvider: AuthProvider;
+
+  @Column({ length: 20, unique: true, nullable: true })
+  refreshToken?: string;
 }


### PR DESCRIPTION
## 🎫 [DMVM-194] 

- ✨ 새로운 기능 추가
업체가 몽글 서비스를 이용할 수 있도록 업체 로그인을 구현하고 이에 대한 인증 인가 시스템을 만들었습니ㅏㄷ.

## 변경 사항에 대한 설명
+ Business entity 로그인 기능

## 테스트 방법
/v1/auth/login으로 Body안 userType을 business로 설정 하여 전송

## 변경된 환경
Customer 뿐만 아니라 Driver, Business 또한 인증인가가 처리될 수 있도록 합니다.
저번 Chat PR 에서 이야기한 것처럼 Customer, Driver, Business 이를 통틀어 인증인가에 사용되는 것을 'User'라고 지칭하겠습니다.

앞으로 로그인은 UserDto를 통해 이루어지며 Response또한 UserDto를 통해 이루어집니다.
때문에 로그인시에 필요한 프로퍼티의 이름이 변경되었습니다.

customerName => name

또한 login api에 대한 Response가 UserDto로 변함에 따라 프로퍼티가 몇개 삭제 및 수정되었습니다.

customerId => userId
customerName => name
customerPhoneNumber => phoneNumber
customerLocation 삭제

## 참고 사항
CurrentCustomer, CurrentDriver, CurrentBusiness로 조회 가능합니다. 만약 Customer 토큰으로 CurrentBusiness를 호출하면 403이 return됩니다.

[DMVM-194]: https://dogbusiness.atlassian.net/browse/DMVM-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ