### PR TITLE
fix: cors localhost:3000 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,11 @@ async function bootstrap() {
   });
 
   app.enableCors({
-    origin: ['https://mgmg.life', 'http://localhost:8000'],
+    origin: [
+      'https://mgmg.life',
+      'http://localhost:8000',
+      'http://localhost:3000',
+    ],
   });
 
   app.useLogger(app.get<LoggerService>(LoggerService));


### PR DESCRIPTION
## 🎫 X

- 🔄 기존 기능의 변경

## 변경 사항에 대한 설명

GlobalCors 설정에 localhost:3000을 추가합니다.

## 테스트 방법

React 등 Front 프레임워크를 통해 아무 API로 요청을 보내주세요

## 변경된 환경

전체적으로 localhost:3000의 요청을 처리할 수 있게 변경되었습니다.
