### PR TITLE
fix: global cors에 https://web-view.mgmg.life 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ async function bootstrap() {
   app.enableCors({
     origin: [
       'https://mgmg.life',
+      'https://web-view.mgmg.life',
       'http://localhost:8000',
       'http://localhost:3000',
     ],


### PR DESCRIPTION
## 🎫 [X]


## 변경 사항에 대한 설명

Mongle Webview의 도메인인 https://web-view.mgmg.life를 global cors에 등록합니다.