### PR TITLE
fix: 도메인으로 소켓 서빙하기 위하여 ChatGateWay namespace 변경

### DIFF
--- a/src/chat/presentation/chat.gateway.ts
+++ b/src/chat/presentation/chat.gateway.ts
@@ -4,22 +4,22 @@ import {
   OnGatewayConnection,
   OnGatewayDisconnect,
   WebSocketGateway,
-  WebSocketServer,
-} from '@nestjs/websockets';
-import { Server, Socket } from 'socket.io';
-import { ForbiddenException, Logger, NotFoundException } from '@nestjs/common';
-import { ChatMessageDto, ChatRoomDto } from './chat.dto';
-import { AuthService } from '../../auth/application/auth.service';
-import { Subscribe } from '../decorator/socket.decorator';
-import { UnauthorizedException } from '@nestjs/common/exceptions';
-import { ChatService } from '../application/chat.service';
-import { UserDto } from '../../auth/presentation/user.dto';
+  WebSocketServer
+} from "@nestjs/websockets";
+import { Server, Socket } from "socket.io";
+import { ForbiddenException, Logger, NotFoundException } from "@nestjs/common";
+import { ChatMessageDto, ChatRoomDto } from "./chat.dto";
+import { AuthService } from "../../auth/application/auth.service";
+import { Subscribe } from "../decorator/socket.decorator";
+import { UnauthorizedException } from "@nestjs/common/exceptions";
+import { ChatService } from "../application/chat.service";
+import { UserDto } from "../../auth/presentation/user.dto";
 
 export class UserSocket extends Socket {
   user: UserDto;
 }
 
-@WebSocketGateway(5000, { namespace: 'chat' })
+@WebSocketGateway(5000)
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private readonly logger: Logger = new Logger(ChatGateway.name);
 


### PR DESCRIPTION
## 🎫 [X]

- 🔄 기존 기능의 변경

## 변경 사항에 대한 설명

chat.mgmg.life 도메인으로 socket을 서빙하기 위하여 네임스페이스를 제거합니다.

## 테스트 방법

wss://chat.mgmg.life로 socket connection을 시도하세요

## 변경된 환경

기존 ChatGateWay namespace /chat에서 /로 변경
