### PR TITLE
fix: ExceptionFilter NotFoundException log 해제 ( 불특정 다수 접근 )

### DIFF
--- a/src/common/filters/exception.filters.ts
+++ b/src/common/filters/exception.filters.ts
@@ -128,10 +128,10 @@ export class NotFoundExceptionFilter implements ExceptionFilter {
     const status = HttpStatus.NOT_FOUND;
     const responseEntity = ResponseEntity.NOT_FOUND('찾을 수 없습니다.');
 
-    this.logger.warn(
-      `Http Status: ${status}, path: ${request.url}, message: ${exception.message}`,
-      exception.stack,
-    );
+    // this.logger.warn(
+    //   `Http Status: ${status}, path: ${request.url}, message: ${exception.message}`,
+    //   exception.stack,
+    // );
 
     response.status(status).json(responseEntity);
   }


### PR DESCRIPTION
## 🎫 [X]


## 변경 사항에 대한 설명

지속해서 불특정 path에 접근하려는 시도가 있어서 로깅을 해제합니다.
