### PR TITLE
fix: 기획 변경으로 인한 otp API의 인증/인가 제한 제거

### DIFF
--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpStatus, Post, Query, Req } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post, Query, Req } from '@nestjs/common';
 import { AuthService } from '../application/auth.service';
 import { AuthDto, OtpRequestDto, OtpResponseDto } from './auth.dto';
 import {
@@ -100,7 +100,7 @@ export class AuthController {
     type: String,
   })
   @GroupValidation([CrudGroup.create])
-  @Auth(HttpStatus.CREATED)
+  @HttpCode(HttpStatus.CREATED)
   @Post('/otp')
   async generatedOtpAndSend(
     @Body() dto: OtpRequestDto,
@@ -138,7 +138,7 @@ export class AuthController {
     description: 'OTP 검증 성공',
   })
   @GroupValidation([CrudGroup.update])
-  @Auth(HttpStatus.OK)
+  @HttpCode(HttpStatus.OK)
   @Post('/otp/verification')
   async otpVerify(
     @CurrentUser() user: UserDto,


### PR DESCRIPTION

## 🎫 [X]

- 🔄 기존 기능의 변경

## 변경 사항에 대한 설명

기획변경으로 인하여 로그인 전 OTP를 사용하기 때문에 OTP관려 API에 대한 인증/인가 제한을 제거합니다.

## 테스트 방법

JWT 토큰 없이 API 호출

## 참고 사항

남용의 우려가 있으므로 **최대한 빠른시일내에 API Key와 Rate Limit을 적용 해야 합니다.**
