### PR TITLE
fix: otpVerify 인증/인가 해제

### DIFF
--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -137,6 +137,7 @@ export class AuthController {
     type: OtpResponseDto,
     description: 'OTP 검증 성공',
   })
+  @ApiKey()
   @GroupValidation([CrudGroup.update])
   @Post('/otp/verification')
   async otpVerify(

--- a/src/auth/presentation/auth.controller.ts
+++ b/src/auth/presentation/auth.controller.ts
@@ -138,7 +138,6 @@ export class AuthController {
     description: 'OTP 검증 성공',
   })
   @GroupValidation([CrudGroup.update])
-  @Auth(HttpStatus.OK)
   @Post('/otp/verification')
   async otpVerify(
     @CurrentUser() user: UserDto,


### PR DESCRIPTION
## 🎫 [X]

- 🔄 기존 기능의 변경

otp관련된 API 모두 인증/인가를 해제하고 ApiKeyGuard를 적용합니다, 

## 테스트 방법
otp/verfication API Key 없이 호출
